### PR TITLE
feature: add aws-sdk-secretsmanager and java-jwt dependencies in app package

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -137,5 +137,17 @@
 			<artifactId>spring-rabbit-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<version>1.12.668</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.4.0</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Depois de análise do build da action percebi que estavam faltando a inclusão dessas dependências no pom do app. Elas são necessárias para a criação do bean da classe WebConfig que agora tem os filtros que fazem o validação do token nas requisições do pedido