### PR TITLE
feature: load jwt key without awsSecrets

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -139,21 +139,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-secretsmanager</artifactId>
-			<version>1.12.668</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
 			<version>4.4.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-sts</artifactId>
-			<version>1.12.668</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/app/src/main/java/br/com/fiap/lanchonete/application/device/rest/filter/JwtTokenFilter.java
+++ b/app/src/main/java/br/com/fiap/lanchonete/application/device/rest/filter/JwtTokenFilter.java
@@ -1,14 +1,9 @@
 package br.com.fiap.lanchonete.application.device.rest.filter;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.servlet.FilterChain;
@@ -17,7 +12,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -33,13 +27,9 @@ public class JwtTokenFilter extends OncePerRequestFilter
     private final ObjectMapper mapper;
     private String jwtSecret;
 
-    public JwtTokenFilter(ObjectMapper mapper) {
+    public JwtTokenFilter(ObjectMapper mapper, String jwtSecretValue) {
         this.mapper = mapper;
-        try {
-            this.jwtSecret = this.getJwtSecret();
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        this.jwtSecret = jwtSecretValue;
     }
 
     @Override
@@ -100,18 +90,5 @@ public class JwtTokenFilter extends OncePerRequestFilter
                                         .build()
                         )
         );
-    }
-
-    /**
-     * Metodo que busca o token do secrets manager.
-     * @return
-     * @throws JsonProcessingException
-     */
-    private String getJwtSecret() throws JsonProcessingException {
-        AWSSecretsManager client = AWSSecretsManagerClientBuilder.standard().build();
-        GetSecretValueRequest request = new GetSecretValueRequest().withSecretId("jwt-secret-key");
-        GetSecretValueResult result = client.getSecretValue(request);
-        Map<String, String> secretMap = this.mapper.readValue(result.getSecretString(), Map.class);
-        return secretMap.get("jwt-key");
     }
 }

--- a/app/src/main/java/br/com/fiap/lanchonete/infrastructure/config/WebConfig.java
+++ b/app/src/main/java/br/com/fiap/lanchonete/infrastructure/config/WebConfig.java
@@ -2,6 +2,7 @@ package br.com.fiap.lanchonete.infrastructure.config;
 
 import br.com.fiap.lanchonete.application.device.rest.filter.JwtTokenFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,8 @@ import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 @Configuration
 public class WebConfig {
     private static final String CHARSET_ENCODING = "UTF-8";
+    @Value("${jwt.key.value}")
+    private String jwtKeyValue;
 
     @Bean
     public LocaleResolver localeResolver(){
@@ -43,7 +46,7 @@ public class WebConfig {
     public FilterRegistrationBean jwtTokenFilter() {
         FilterRegistrationBean registrationBean = new FilterRegistrationBean();
         registrationBean.setName("jwtTokenFilter");
-        registrationBean.setFilter(new JwtTokenFilter(new ObjectMapper()));
+        registrationBean.setFilter(new JwtTokenFilter(new ObjectMapper(),this.jwtKeyValue));
         registrationBean.addUrlPatterns("/pedido-service/v1/*");
         registrationBean.setOrder(1);
         return registrationBean;

--- a/app/src/main/resources/application-dev.properties
+++ b/app/src/main/resources/application-dev.properties
@@ -52,3 +52,5 @@ logging.level.root=INFO
 
 # Feign Clients
 spring.cloud.openfeign.client.config.pagamentoMock-service-client.url=http://192.168.1.108:8081/pagamento-mock-service/v1
+
+jwt.key.value=${JWT_KEY_VALUE}

--- a/app/src/main/resources/application-prod.properties
+++ b/app/src/main/resources/application-prod.properties
@@ -52,3 +52,5 @@ logging.level.root=INFO
 
 # Feign Clients
 spring.cloud.openfeign.client.config.pagamentoMock-service-client.url=http://${PAGAMENTO_MOCK_HOST}:8081/pagamento-mock-service/v1
+
+jwt.key.value=${JWT_KEY_VALUE}


### PR DESCRIPTION
Carregar credenciais AWS em um Pod do Amazon EKS (Elastic Kubernetes Service) de forma segura necessita usar IAM Roles for Service Accounts (IRSA) que por sua vez demanda a criação de um OpenID Connect (OIDC) para associar ao cluster.

Com isso foi visto o impedimento pois no AWS não é possível criar um recurso OpenID Connect (OIDC).

Com isso o jwt-key será armazenado na secret do Kubernetes e sem seguida passado à aplicação por variável de de ambiente